### PR TITLE
Feat-11 / 게시물 전체 조회

### DIFF
--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -28,6 +28,8 @@ public class NewsService {
         return mapToDTO(news);
     }
 
+
+
     @Transactional(readOnly = true)
     public Page<NewsDTO> getAllNews(int pageNo, int pageSize) {
         PageRequest pageable = PageRequest.of(pageNo - 1, pageSize);


### PR DESCRIPTION
# 제목 : Feat: add getAllNews 기능 추가(게시물 전체 조회)

### 실수로 news 브랜치에 개발도중 commit & push 함
### 그래서 아래에 코드 변경점 직접 작성해 올립니다

## 🔘Part

- 게시물 전체조회 파트

## 🔎 작업 내용

- 컨트롤러와 서비스 로직 추가


## 🔧 앞으로의 과제

- 나머지 수정 삭제까지의 기능 남아있음

## ➕ 이슈 링크

- https://github.com/5trillion500million/newsfeed/issues/10

`    
// 뉴스 전체 조회 (페이지네이션 포함)
    @GetMapping
    public ResponseEntity<Page<NewsDTO>> getAllNews(
            @RequestParam(defaultValue = "1") int pageNo,
            @RequestParam(defaultValue = "10") int pageSize) {
        Page<NewsDTO> newsPage = newsService.getAllNews(pageNo, pageSize);
        return ResponseEntity.ok(newsPage);
    }
`

` 
@Transactional(readOnly = true)
    public Page<NewsDTO> getAllNews(int pageNo, int pageSize) {
        PageRequest pageable = PageRequest.of(pageNo - 1, pageSize);
        return newsRepository.findAll(pageable).map(this::mapToDTO);
    }
`

코드 변경점은 위와 같습니다.