### PR TITLE
Feat-11 /게시물 단건조회 기능

### DIFF
--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -30,4 +30,11 @@ public class NewsController {
         Page<NewsDTO> newsPage = newsService.getAllNews(pageNo, pageSize);
         return ResponseEntity.ok(newsPage);
     }
+
+    // 특정 뉴스 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<NewsDTO> getNews(@PathVariable Long id) {
+        NewsDTO newsDTO = newsService.getNews(id);
+        return ResponseEntity.ok(newsDTO);
+    }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -36,6 +36,14 @@ public class NewsService {
         return newsRepository.findAll(pageable).map(this::mapToDTO);
     }
 
+    @Transactional(readOnly = true)
+    public NewsDTO getNews(Long id) {
+        News news = newsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("News not found"));
+        return mapToDTO(news);
+    }
+
+
     private NewsDTO mapToDTO(News news) {
         return NewsDTO.builder()
                 .id(news.getId())


### PR DESCRIPTION
# 제목 : Feat: Add NewsPost

## 🔘Part

- 게시물 단건조회 기능

## 🔎 작업 내용

- 게시물 단건조회 기능 컨트롤러, 서비스 로직 추가


## 🔧 앞으로의 과제

- 나머지 수정 삭제까지의 기능 남아있음

## ➕ 이슈 링크
https://github.com/5trillion500million/newsfeed/issues/11