### PR TITLE
Feat-11 / 게시물 단건조회

### DIFF
--- a/src/main/java/com/sparta/newsfeedproject/domain/comment/dto/CommentDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/comment/dto/CommentDTO.java
@@ -1,0 +1,15 @@
+package com.sparta.newsfeedproject.domain.comment.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDTO {
+    private Long id;
+    private String comment;
+    private String authorNickname;
+    private String createdAt;
+}

--- a/src/main/java/com/sparta/newsfeedproject/domain/comment/dto/CommentDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/comment/dto/CommentDTO.java
@@ -2,6 +2,8 @@ package com.sparta.newsfeedproject.domain.comment.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @Builder
@@ -11,5 +13,5 @@ public class CommentDTO {
     private Long id;
     private String comment;
     private String authorNickname;
-    private String createdAt;
+    private LocalDateTime modifiedAt;  // LocalDateTime으로 변경
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/exception/eunm/ErrorCode.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/exception/eunm/ErrorCode.java
@@ -10,12 +10,14 @@ public enum ErrorCode {
     // 400
     NOT_NULL(HttpStatus.BAD_REQUEST, "필수 값 누락", 400),
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "토큰이 존재하지 않음", 400),
+
     // 401 에러
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패", 401),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰", 401),
 
     // 404 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저", 404),
+    NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 뉴스", 404),  // 뉴스가 존재하지 않을 때
 
     // 409
     ALREADY_EMAIL(HttpStatus.CONFLICT, "이미 사용되는 이메일", 409),

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -41,21 +41,4 @@ public class NewsController {
         NewsResponseDTO newsDTO = newsService.getNews(id);
         return ResponseEntity.ok(newsDTO);
     }
-
-    // 뉴스 수정
-    @PutMapping("/{id}")
-    public ResponseEntity<NewsResponseDTO> updateNews(
-            @PathVariable Long id,
-            @Valid @RequestBody NewsRequestDTO newsDTO,
-            @RequestAttribute Member member) {
-        NewsResponseDTO updatedNews = newsService.updateNews(id, member, newsDTO);
-        return ResponseEntity.ok(updatedNews);
-    }
-
-    // 뉴스 삭제
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteNews(@PathVariable Long id, @RequestAttribute Member member) {
-        newsService.deleteNews(id, member);
-        return ResponseEntity.noContent().build();
-    }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -1,8 +1,10 @@
 package com.sparta.newsfeedproject.domain.news.controller;
 
-import com.sparta.newsfeedproject.domain.news.dto.NewsDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsRequestDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
 import com.sparta.newsfeedproject.domain.news.service.NewsService;
 import com.sparta.newsfeedproject.domain.member.entity.Member;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -15,26 +17,45 @@ public class NewsController {
 
     private final NewsService newsService;
 
-    // 뉴스 생성
-    @PostMapping
-    public ResponseEntity<NewsDTO> createNews(@RequestBody NewsDTO newsDTO, @RequestAttribute Member member) {
-        NewsDTO createdNews = newsService.createNews(member, newsDTO);
-        return ResponseEntity.ok(createdNews);
-    }
-
-    // 뉴스 전체 조회 (페이지네이션 포함)
+    // 뉴스 전체 조회 (페이지네이션 + 정렬)
     @GetMapping
-    public ResponseEntity<Page<NewsDTO>> getAllNews(
+    public ResponseEntity<Page<NewsResponseDTO>> getAllNews(
             @RequestParam(defaultValue = "1") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize) {
-        Page<NewsDTO> newsPage = newsService.getAllNews(pageNo, pageSize);
+        Page<NewsResponseDTO> newsPage = newsService.getAllNews(pageNo, pageSize);
         return ResponseEntity.ok(newsPage);
     }
 
-    // 특정 뉴스 조회
+    // 뉴스 생성
+    @PostMapping
+    public ResponseEntity<NewsResponseDTO> createNews(
+            @Valid @RequestBody NewsRequestDTO newsDTO,
+            @RequestAttribute Member member) {
+        NewsResponseDTO createdNews = newsService.createNews(member, newsDTO);
+        return ResponseEntity.ok(createdNews);
+    }
+
+    // 뉴스 단건 조회
     @GetMapping("/{id}")
-    public ResponseEntity<NewsDTO> getNews(@PathVariable Long id) {
-        NewsDTO newsDTO = newsService.getNews(id);
+    public ResponseEntity<NewsResponseDTO> getNews(@PathVariable Long id) {
+        NewsResponseDTO newsDTO = newsService.getNews(id);
         return ResponseEntity.ok(newsDTO);
+    }
+
+    // 뉴스 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<NewsResponseDTO> updateNews(
+            @PathVariable Long id,
+            @Valid @RequestBody NewsRequestDTO newsDTO,
+            @RequestAttribute Member member) {
+        NewsResponseDTO updatedNews = newsService.updateNews(id, member, newsDTO);
+        return ResponseEntity.ok(updatedNews);
+    }
+
+    // 뉴스 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNews(@PathVariable Long id, @RequestAttribute Member member) {
+        newsService.deleteNews(id, member);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -35,7 +35,7 @@ public class NewsController {
         return ResponseEntity.ok(createdNews);
     }
 
-    // 뉴스 단건 조회
+    // 뉴스 단건 조회 (코멘트 포함)
     @GetMapping("/{id}")
     public ResponseEntity<NewsResponseDTO> getNews(@PathVariable Long id) {
         NewsResponseDTO newsDTO = newsService.getNews(id);

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -30,4 +30,11 @@ public class NewsController {
         Page<NewsDTO> newsPage = newsService.getAllNews(pageNo, pageSize);
         return ResponseEntity.ok(newsPage);
     }
+
+    // 특정 뉴스 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<NewsDTO> getNews(@PathVariable Long id) {
+        NewsDTO newsDTO = newsService.getNews(id);
+        return ResponseEntity.ok(newsDTO);
+    }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsRequestDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsRequestDTO.java
@@ -13,6 +13,6 @@ public class NewsRequestDTO {
     @NotBlank(message = "타이틀을 채워야합니다.")
     private String title;
 
-    @NotBlank(message = "content가 채워야합니다.")
+    @NotBlank(message = "content가 채워져야합니다.")
     private String content;
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsRequestDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsRequestDTO.java
@@ -10,9 +10,9 @@ import lombok.*;
 @AllArgsConstructor
 public class NewsRequestDTO {
 
-    @NotBlank(message = "Title is mandatory")
+    @NotBlank(message = "타이틀을 채워야합니다.")
     private String title;
 
-    @NotBlank(message = "Content is mandatory")
+    @NotBlank(message = "content가 채워야합니다.")
     private String content;
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsRequestDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsRequestDTO.java
@@ -1,5 +1,6 @@
 package com.sparta.newsfeedproject.domain.news.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
@@ -7,11 +8,11 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class NewsDTO {
-    private Long id;
+public class NewsRequestDTO {
+
+    @NotBlank(message = "Title is mandatory")
     private String title;
+
+    @NotBlank(message = "Content is mandatory")
     private String content;
-    private String authorNickname;
-    private int commentCount;
-    private String modifyAt;
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsResponseDTO.java
@@ -1,0 +1,17 @@
+package com.sparta.newsfeedproject.domain.news.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsResponseDTO {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String authorNickname;
+    private String modifyAt;
+}

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsResponseDTO.java
@@ -1,6 +1,9 @@
 package com.sparta.newsfeedproject.domain.news.dto;
 
+import com.sparta.newsfeedproject.domain.comment.dto.CommentDTO;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -8,10 +11,10 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NewsResponseDTO {
-
     private Long id;
     private String title;
     private String content;
     private String authorNickname;
     private String modifyAt;
+    private List<CommentDTO> commentList;  // 코멘트 리스트 추가
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/entity/News.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/entity/News.java
@@ -1,11 +1,15 @@
 package com.sparta.newsfeedproject.domain.news.entity;
 
 import com.sparta.newsfeedproject.domain.audit.Auditable;
+import com.sparta.newsfeedproject.domain.comment.entity.Comment;
 import com.sparta.newsfeedproject.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Getter
+@Setter
 @Builder
 @Entity
 @Table(name = "news")
@@ -27,8 +31,6 @@ public class News extends Auditable {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    public void updateNews(String title, String content) {
-        this.title = title;
-        this.content = content;
-    }
+    @OneToMany(mappedBy = "news", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Comment> comments;
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -77,7 +77,8 @@ public class NewsService {
                 .id(comment.getId())
                 .comment(comment.getComment())
                 .authorNickname(comment.getMember().getNickName())
-                .createdAt(comment.getModifiedAt().toString())  // 변경된 날짜 사용
+                .modifiedAt(comment.getModifiedAt())  // LocalDateTime 로 변경함
                 .build();
     }
+
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -36,6 +36,14 @@ public class NewsService {
         return newsRepository.findAll(pageable).map(this::mapToDTO);
     }
 
+    @Transactional(readOnly = true)
+    public NewsDTO getNews(Long id) {
+        News news = newsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("News not found"));
+        return mapToDTO(news);
+    }
+
+
     private NewsDTO mapToDTO(News news) {
         return NewsDTO.builder()
                 .id(news.getId())

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -2,6 +2,8 @@ package com.sparta.newsfeedproject.domain.news.service;
 
 import com.sparta.newsfeedproject.domain.comment.dto.CommentDTO;
 import com.sparta.newsfeedproject.domain.comment.entity.Comment;
+import com.sparta.newsfeedproject.domain.exception.CustomException;
+import com.sparta.newsfeedproject.domain.exception.eunm.ErrorCode;
 import com.sparta.newsfeedproject.domain.news.dto.NewsRequestDTO;
 import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
 import com.sparta.newsfeedproject.domain.news.entity.News;
@@ -43,8 +45,9 @@ public class NewsService {
     @Transactional(readOnly = true)
     public NewsResponseDTO getNews(Long id) {
         News news = newsRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("News not found"));
+                .orElseThrow(() -> new CustomException(ErrorCode.NEWS_NOT_FOUND));  // CustomException 사용
 
+        // Comment 리스트를 DTO로 변환
         List<CommentDTO> commentList = news.getComments().stream()
                 .map(this::mapToCommentDTO)
                 .collect(Collectors.toList());
@@ -69,13 +72,12 @@ public class NewsService {
                 .build();
     }
 
-    // Comment 엔티티를 CommentDTO로 변환하는 메서드 추가
     private CommentDTO mapToCommentDTO(Comment comment) {
         return CommentDTO.builder()
                 .id(comment.getId())
                 .comment(comment.getComment())
                 .authorNickname(comment.getMember().getNickName())
-                .createdAt(comment.getCreatedAt().toString())
+                .createdAt(comment.getModifiedAt().toString())  // 변경된 날짜 사용
                 .build();
     }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -1,5 +1,7 @@
 package com.sparta.newsfeedproject.domain.news.service;
 
+import com.sparta.newsfeedproject.domain.comment.dto.CommentDTO;
+import com.sparta.newsfeedproject.domain.comment.entity.Comment;
 import com.sparta.newsfeedproject.domain.news.dto.NewsRequestDTO;
 import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
 import com.sparta.newsfeedproject.domain.news.entity.News;
@@ -11,6 +13,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +44,19 @@ public class NewsService {
     public NewsResponseDTO getNews(Long id) {
         News news = newsRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("News not found"));
-        return mapToResponseDTO(news);
+
+        List<CommentDTO> commentList = news.getComments().stream()
+                .map(this::mapToCommentDTO)
+                .collect(Collectors.toList());
+
+        return NewsResponseDTO.builder()
+                .id(news.getId())
+                .title(news.getTitle())
+                .content(news.getContent())
+                .authorNickname(news.getAuthor().getNickName())
+                .modifyAt(news.getModifiedAt().toString())
+                .commentList(commentList)  // 코멘트 리스트 추가
+                .build();
     }
 
     private NewsResponseDTO mapToResponseDTO(News news) {
@@ -49,6 +66,16 @@ public class NewsService {
                 .content(news.getContent())
                 .authorNickname(news.getAuthor().getNickName())
                 .modifyAt(news.getModifiedAt().toString())
+                .build();
+    }
+
+    // Comment 엔티티를 CommentDTO로 변환하는 메서드 추가
+    private CommentDTO mapToCommentDTO(Comment comment) {
+        return CommentDTO.builder()
+                .id(comment.getId())
+                .comment(comment.getComment())
+                .authorNickname(comment.getMember().getNickName())
+                .createdAt(comment.getCreatedAt().toString())
                 .build();
     }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -42,32 +42,6 @@ public class NewsService {
         return mapToResponseDTO(news);
     }
 
-    @Transactional
-    public NewsResponseDTO updateNews(Long id, Member author, NewsRequestDTO newsDTO) {
-        News news = newsRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("News not found"));
-
-        if (!news.getAuthor().equals(author)) {
-            throw new IllegalStateException("Only the author can update this news.");
-        }
-
-        news.updateNews(newsDTO.getTitle(), newsDTO.getContent());
-        newsRepository.save(news);
-        return mapToResponseDTO(news);
-    }
-
-    @Transactional
-    public void deleteNews(Long id, Member author) {
-        News news = newsRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("News not found"));
-
-        if (!news.getAuthor().equals(author)) {
-            throw new IllegalStateException("Only the author can delete this news.");
-        }
-
-        newsRepository.delete(news);
-    }
-
     private NewsResponseDTO mapToResponseDTO(News news) {
         return NewsResponseDTO.builder()
                 .id(news.getId())


### PR DESCRIPTION
# 제목 : refactor: add getNews entity 부분 책임 분배(요청,반응)

## +) 전체조회시 content와 comment 둘다 가능하게 변경

## 🔘Part

- 게시물 단건조회 파트

## 🔎 작업 내용

- dto 요청과 반응으로 분배, 예외처리 폴더 추가, 서비스 로직 코드 변경


## 🔧 앞으로의 과제

- 나머지 수정 삭제까지의 기능 남아있음

## ➕ 이슈 링크
- https://github.com/5trillion500million/newsfeed/issues/11