### PR TITLE
Feat 21

### DIFF
--- a/src/main/java/com/sparta/newsfeedproject/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/member/controller/MemberController.java
@@ -41,8 +41,4 @@ public class MemberController {
                 .status(HttpStatus.OK)
                 .body(response);
     }
-    @GetMapping("/index")
-    public void test(@LoginUser Member member){
-        System.out.println(member.getNickName());
-    }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/member/entity/News.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/member/entity/News.java
@@ -1,4 +1,0 @@
-package com.sparta.newsfeedproject.domain.member.entity;
-
-public class News {
-}

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -3,7 +3,8 @@ package com.sparta.newsfeedproject.domain.news.controller;
 import com.sparta.newsfeedproject.domain.member.resolver.util.LoginUser;
 import com.sparta.newsfeedproject.domain.news.dto.NewsCreateRequestDTO;
 import com.sparta.newsfeedproject.domain.news.dto.NewsCreateResponseDTO;
-import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsPageReadResponseDto;
+import com.sparta.newsfeedproject.domain.news.dto.NewsReadResponseDTO;
 import com.sparta.newsfeedproject.domain.news.service.NewsService;
 import com.sparta.newsfeedproject.domain.member.entity.Member;
 import jakarta.validation.Valid;
@@ -21,10 +22,10 @@ public class NewsController {
 
     // 뉴스 전체 조회 (페이지네이션 + 정렬)
     @GetMapping
-    public ResponseEntity<Page<NewsResponseDTO>> getAllNews(
+    public ResponseEntity<Page<NewsPageReadResponseDto>> getAllNews(
             @RequestParam(defaultValue = "1") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize) {
-        Page<NewsResponseDTO> newsPage = newsService.getAllNews(pageNo, pageSize);
+        Page<NewsPageReadResponseDto> newsPage = newsService.getAllNews(pageNo, pageSize);
         return ResponseEntity.ok(newsPage);
     }
 
@@ -39,8 +40,8 @@ public class NewsController {
 
     // 뉴스 단건 조회 (코멘트 포함)
     @GetMapping("/{id}")
-    public ResponseEntity<NewsResponseDTO> getNews(@PathVariable Long id) {
-        NewsResponseDTO newsDTO = newsService.getNews(id);
+    public ResponseEntity<NewsReadResponseDTO> getNews(@PathVariable Long id) {
+        NewsReadResponseDTO newsDTO = newsService.getNews(id);
         return ResponseEntity.ok(newsDTO);
     }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/controller/NewsController.java
@@ -1,6 +1,8 @@
 package com.sparta.newsfeedproject.domain.news.controller;
 
-import com.sparta.newsfeedproject.domain.news.dto.NewsRequestDTO;
+import com.sparta.newsfeedproject.domain.member.resolver.util.LoginUser;
+import com.sparta.newsfeedproject.domain.news.dto.NewsCreateRequestDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsCreateResponseDTO;
 import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
 import com.sparta.newsfeedproject.domain.news.service.NewsService;
 import com.sparta.newsfeedproject.domain.member.entity.Member;
@@ -28,10 +30,10 @@ public class NewsController {
 
     // 뉴스 생성
     @PostMapping
-    public ResponseEntity<NewsResponseDTO> createNews(
-            @Valid @RequestBody NewsRequestDTO newsDTO,
-            @RequestAttribute Member member) {
-        NewsResponseDTO createdNews = newsService.createNews(member, newsDTO);
+    public ResponseEntity<NewsCreateResponseDTO> createNews(
+            @Valid @RequestBody NewsCreateRequestDTO newsDTO,
+            @LoginUser Member member) {
+        NewsCreateResponseDTO createdNews = newsService.createNews(member, newsDTO);
         return ResponseEntity.ok(createdNews);
     }
 

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsCreateRequestDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsCreateRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class NewsRequestDTO {
+public class NewsCreateRequestDTO {
 
     @NotBlank(message = "타이틀을 채워야합니다.")
     private String title;

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsCreateResponseDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsCreateResponseDTO.java
@@ -1,0 +1,14 @@
+package com.sparta.newsfeedproject.domain.news.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsCreateResponseDTO {
+    private Long id;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsPageReadResponseDto.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsPageReadResponseDto.java
@@ -1,0 +1,19 @@
+package com.sparta.newsfeedproject.domain.news.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsPageReadResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private String authorNickname;
+    private int commentCount;
+    private LocalDateTime modifyAt;
+}

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsReadResponseDTO.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/dto/NewsReadResponseDTO.java
@@ -3,6 +3,7 @@ package com.sparta.newsfeedproject.domain.news.dto;
 import com.sparta.newsfeedproject.domain.comment.dto.CommentDTO;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -10,11 +11,11 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class NewsResponseDTO {
+public class NewsReadResponseDTO {
     private Long id;
     private String title;
     private String content;
     private String authorNickname;
-    private String modifyAt;
+    private LocalDateTime modifyAt;
     private List<CommentDTO> commentList;  // 코멘트 리스트 추가
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -6,7 +6,8 @@ import com.sparta.newsfeedproject.domain.exception.CustomException;
 import com.sparta.newsfeedproject.domain.exception.eunm.ErrorCode;
 import com.sparta.newsfeedproject.domain.news.dto.NewsCreateRequestDTO;
 import com.sparta.newsfeedproject.domain.news.dto.NewsCreateResponseDTO;
-import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsPageReadResponseDto;
+import com.sparta.newsfeedproject.domain.news.dto.NewsReadResponseDTO;
 import com.sparta.newsfeedproject.domain.news.entity.News;
 import com.sparta.newsfeedproject.domain.news.repository.NewsRepository;
 import com.sparta.newsfeedproject.domain.member.entity.Member;
@@ -38,27 +39,27 @@ public class NewsService {
     }
 
     @Transactional(readOnly = true)
-    public Page<NewsResponseDTO> getAllNews(int pageNo, int pageSize) {
+    public Page<NewsPageReadResponseDto> getAllNews(int pageNo, int pageSize) {
         PageRequest pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return newsRepository.findAll(pageable).map(this::mapToResponseDTO);
+        return newsRepository.findAll(pageable).map(this::mapToReadPageResponseDTO);
     }
 
     @Transactional(readOnly = true)
-    public NewsResponseDTO getNews(Long id) {
+    public NewsReadResponseDTO getNews(Long id) {
         News news = newsRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.NEWS_NOT_FOUND));  // CustomException 사용
 
         // Comment 리스트를 DTO로 변환
         List<CommentDTO> commentList = news.getComments().stream()
                 .map(this::mapToCommentDTO)
-                .collect(Collectors.toList());
+                .toList();
 
-        return NewsResponseDTO.builder()
+        return NewsReadResponseDTO.builder()
                 .id(news.getId())
                 .title(news.getTitle())
                 .content(news.getContent())
                 .authorNickname(news.getAuthor().getNickName())
-                .modifyAt(news.getModifiedAt().toString())
+                .modifyAt(news.getModifiedAt())
                 .commentList(commentList)  // 코멘트 리스트 추가
                 .build();
     }
@@ -71,13 +72,14 @@ public class NewsService {
                 .build();
     }
 
-    private NewsResponseDTO mapToResponseDTO(News news) {
-        return NewsResponseDTO.builder()
+    private NewsPageReadResponseDto mapToReadPageResponseDTO(News news) {
+        return NewsPageReadResponseDto.builder()
                 .id(news.getId())
                 .title(news.getTitle())
                 .content(news.getContent())
                 .authorNickname(news.getAuthor().getNickName())
-                .modifyAt(news.getModifiedAt().toString())
+                .modifyAt(news.getModifiedAt())
+                .commentCount(news.getComments().size())
                 .build();
     }
 

--- a/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/news/service/NewsService.java
@@ -4,7 +4,8 @@ import com.sparta.newsfeedproject.domain.comment.dto.CommentDTO;
 import com.sparta.newsfeedproject.domain.comment.entity.Comment;
 import com.sparta.newsfeedproject.domain.exception.CustomException;
 import com.sparta.newsfeedproject.domain.exception.eunm.ErrorCode;
-import com.sparta.newsfeedproject.domain.news.dto.NewsRequestDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsCreateRequestDTO;
+import com.sparta.newsfeedproject.domain.news.dto.NewsCreateResponseDTO;
 import com.sparta.newsfeedproject.domain.news.dto.NewsResponseDTO;
 import com.sparta.newsfeedproject.domain.news.entity.News;
 import com.sparta.newsfeedproject.domain.news.repository.NewsRepository;
@@ -26,14 +27,14 @@ public class NewsService {
     private final NewsRepository newsRepository;
 
     @Transactional
-    public NewsResponseDTO createNews(Member author, NewsRequestDTO newsDTO) {
+    public NewsCreateResponseDTO createNews(Member author, NewsCreateRequestDTO newsDTO) {
         News news = News.builder()
                 .author(author)
                 .title(newsDTO.getTitle())
                 .content(newsDTO.getContent())
                 .build();
         newsRepository.save(news);
-        return mapToResponseDTO(news);
+        return mapToCrateResponseDTO(news);
     }
 
     @Transactional(readOnly = true)
@@ -59,6 +60,14 @@ public class NewsService {
                 .authorNickname(news.getAuthor().getNickName())
                 .modifyAt(news.getModifiedAt().toString())
                 .commentList(commentList)  // 코멘트 리스트 추가
+                .build();
+    }
+
+    private NewsCreateResponseDTO mapToCrateResponseDTO(News news) {
+        return NewsCreateResponseDTO.builder()
+                .id(news.getId())
+                .title(news.getTitle())
+                .content(news.getContent())
                 .build();
     }
 


### PR DESCRIPTION
제목 : refactor : CreateNews refactoring, Add Paging News Comment Count
- 뉴스생성 전체 흐름 세분화
- 뉴스 전체조회시 댓글숫자 Null 출력 수정
🔘Part

    뉴스생성 DTO 세분화
    게시물 전체조회 파트

🔎 작업 내용

    dto 요청과 반응으로 분배, 서비스 로직 코드 변경

🔧 앞으로의 과제

    나머지 수정 삭제까지의 기능 남아있음

➕ 이슈 링크

https://github.com/5trillion500million/newsfeed/issues/21